### PR TITLE
Feature/Add Laravel 12 support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -68,7 +68,7 @@ jobs:
         continue-on-error: true
 
   test:
-    name: Test (PHP ${{ matrix.php-version }})
+    name: Test (PHP ${{ matrix.php-version }}, Illuminate ${{ matrix.illuminate }})
     runs-on: ubuntu-latest
     needs: [lint]
 
@@ -76,6 +76,7 @@ jobs:
       fail-fast: false
       matrix:
         php-version: ["8.2", "8.3", "8.4"]
+        illuminate: ["^11.0", "^12.0"]
 
     steps:
       - name: Checkout
@@ -92,17 +93,19 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.composer/cache
-          key: php-${{ matrix.php-version }}-composer-${{ hashFiles('**/composer.json') }}
-          restore-keys: php-${{ matrix.php-version }}-composer-
+          key: php-${{ matrix.php-version }}-illuminate-${{ matrix.illuminate }}-composer-${{ hashFiles('**/composer.json') }}
+          restore-keys: php-${{ matrix.php-version }}-illuminate-${{ matrix.illuminate }}-composer-
 
       - name: Install dependencies
-        run: composer install --prefer-dist --no-progress
+        run: |
+          composer require "illuminate/collections:${{ matrix.illuminate }}" --no-update
+          composer install --prefer-dist --no-progress
 
       - name: Run tests
         run: composer test
 
       - name: Upload coverage artifact
-        if: matrix.php-version == '8.4'
+        if: matrix.php-version == '8.4' && matrix.illuminate == '^12.0'
         uses: actions/upload-artifact@v4
         with:
           name: coverage-report

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     "ext-json": "*",
     "ramsey/uuid": "^4.1.0",
     "nesbot/carbon": "^3.2.0",
-    "illuminate/collections": "^11.0.0",
+    "illuminate/collections": "^11.0.0 || ^12.0.0",
     "lambdish/phunctional": "^2.1.0",
     "doctrine/instantiator": "^2.0.0",
     "complex-heart/contracts": "^3.0.0"

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -2,13 +2,8 @@
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          bootstrap="vendor/autoload.php"
          colors="true"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.5/phpunit.xsd"
          cacheDirectory=".phpunit.cache">
-    <coverage>
-        <report>
-            <clover outputFile="./coverage.xml"/>
-        </report>
-    </coverage>
     <testsuites>
         <testsuite name="unit">
             <directory>./tests</directory>


### PR DESCRIPTION
## Summary
- Widen `illuminate/collections` constraint to `^11.0.0 || ^12.0.0`
- Add Illuminate version dimension to CI test matrix (PHP 8.2/8.3/8.4 × Illuminate 11/12 = 6 combos)
- Update `phpunit.xml` XSD to 11.5 and remove deprecated `<coverage>` block (already handled by CLI flags)
- Coverage artifact uploaded only from PHP 8.4 + Illuminate 12 — SonarCloud receives a single report

## Context
This is a prerequisite for Laravel 12 support in the downstream packages:
- `complex-heart/criteria` (depends on `domain-model ^5.0.0`) — resolves automatically
- `complex-heart/sdk` (depends on `domain-model ^5.0.0`) — resolves automatically  
- `complex-heart/on-laravel` (depends on `sdk ^3.0.0`) — blocked by this ([PR #10](https://github.com/ComplexHeart/on-laravel/pull/10))

## Test plan
- [x] CI passes all 6 matrix combinations
- [x] SonarCloud receives one coverage report (PHP 8.4 + Illuminate ^12.0)
- [x] Local tests pass: 127 passed (243 assertions)